### PR TITLE
Add -Q for setting 802.1p priority.

### DIFF
--- a/doc/arping.8
+++ b/doc/arping.8
@@ -86,6 +86,9 @@ Turn on promiscious mode on interface, use this if you don\(cq\&t
 Send ARP replies instead of requests\&. Useful with \-U\&.
 .IP "\-q"
 Does not display messages, except error messages\&.
+.IP "\-Q \fIpriority\fP"
+802.1p priority to set. Should be used with 802.1Q tag (-V)\&.
+Defaults to 0\&.
 .IP "\-r"
 Raw output: only the MAC/IP address is displayed for each reply\&.
 .IP "\-R"

--- a/doc/arping.8
+++ b/doc/arping.8
@@ -5,7 +5,7 @@
 arping \- sends arp and/or ip pings to a given host
 .PP 
 .SH "SYNOPSIS"
-\fBarping\fP [\-0aAbBdDeFhpqrRuUv] [\-S \fIhost/ip\fP] [\-T \fIhost/ip\fP] [\-s \fIMAC\fP]    [\-t \fIMAC\fP] [\-c \fIcount\fP] [\-i \fIinterface\fP] [ \-w \fIus\fP ] [ \-V \fIvlan\fP ] <\fIhost\fP | \-B>
+\fBarping\fP [\-0aAbBdDeFhpqrRuUv] [\-S \fIhost/ip\fP] [\-T \fIhost/ip\fP] [\-s \fIMAC\fP]    [\-t \fIMAC\fP] [\-c \fIcount\fP] [\-i \fIinterface\fP] [ \-w \fIus\fP ] [ \-V \fIvlan\fP ] [ \-Q \fIpriority\fP ] <\fIhost\fP | \-B>
 .PP 
 \fBarping\fP \-\-help
 .PP 


### PR DESCRIPTION
Priority is set to sent packets. -Q must be used with 802.1Q VLAN tag
option (-V). This option allows to set the PCP field of the 802.1Q header to
values 0 - 7.

Signed-off-by: Nikolay Aleksandrov razor@blackwall.org
