### PR TITLE
Add -Q option to specify 802.1Q priority.

### DIFF
--- a/doc/arping.8
+++ b/doc/arping.8
@@ -5,7 +5,7 @@
 arping \- sends arp and/or ip pings to a given host
 .PP 
 .SH "SYNOPSIS"
-\fBarping\fP [\-0aAbBdDeFhpqrRuUv] [\-S \fIhost/ip\fP] [\-T \fIhost/ip\fP] [\-s \fIMAC\fP]    [\-t \fIMAC\fP] [\-c \fIcount\fP] [\-i \fIinterface\fP] [ \-w \fIus\fP ] [ \-V \fIvlan\fP ] <\fIhost\fP | \-B>
+\fBarping\fP [\-0aAbBdDeFhpqrRuUv] [\-S \fIhost/ip\fP] [\-T \fIhost/ip\fP] [\-s \fIMAC\fP]    [\-t \fIMAC\fP] [\-c \fIcount\fP] [\-i \fIinterface\fP] [ \-w \fIus\fP ] [ \-V \fIvlan\fP ] [ \-Q \fIpriority\fP ] <\fIhost\fP | \-B>
 .PP 
 \fBarping\fP \-\-help
 .PP 
@@ -86,6 +86,9 @@ Turn on promiscious mode on interface, use this if you don\(cq\&t
 Send ARP replies instead of requests\&. Useful with \-U\&.
 .IP "\-q"
 Does not display messages, except error messages\&.
+.IP "\-Q \fIpriority\fP"
+802\&.1p priority to set\&. Should be used with 802\&.1Q tag (\-V)\&.
+Defaults to 0\&.
 .IP "\-r"
 Raw output: only the MAC/IP address is displayed for each reply\&.
 .IP "\-R"

--- a/doc/arping.yodl
+++ b/doc/arping.yodl
@@ -4,7 +4,7 @@ manpagename(arping)(sends arp and/or ip pings to a given host)
 
 manpagesynopsis()
     bf(arping) [-0aAbBdDeFhpqrRuUv] [-S em(host/ip)] [-T em(host/ip)] [-s em(MAC)]    \
-[-t em(MAC)] [-c em(count)] [-i em(interface)] [ -w em(us) ] [ -V em(vlan) ] <em(host) | -B>
+[-t em(MAC)] [-c em(count)] [-i em(interface)] [ -w em(us) ] [ -V em(vlan) ] [ -Q em(priority) ] <em(host) | -B>
 
     bf(arping) --help
 
@@ -67,6 +67,8 @@ switch is not given, -i disables this smartness.
             "own" the MAC address you are using.
     dit(-P) Send ARP replies instead of requests. Useful with -U.
     dit(-q) Does not display messages, except error messages.
+    dit(-Q em(priority)) 802.1p priority to set. Should be used with 802.1Q tag (-V).
+        Defaults to 0.
     dit(-r) Raw output: only the MAC/IP address is displayed for each reply.
     dit(-R) Raw output: Like -r but shows "the other one", can be combined with
 -r.

--- a/src/arping.c
+++ b/src/arping.c
@@ -155,6 +155,7 @@ static uint32_t srcip;            /* autodetected, override with -S/-b/-0 */
 static uint8_t srcmac[ETH_ALEN];  /* autodetected, override with -s */
 
 static int16_t vlan_tag = -1; /* 802.1Q tag to add to packets. -V */
+static int16_t vlan_prio = -1; /* 802.1p prio to use with 802.1Q. -Q */
 
 static int beep = 0;                 /* beep when reply is received. -a */
 static int reverse_beep = 0;         /* beep when expected reply absent. -e */
@@ -597,6 +598,8 @@ extended_usage()
                "\n           Type of timestamp to use for incoming packets. Use -vv when\n"
                "           pinging to list available ones.\n"
 	       "    -q     Does not display messages, except error messages.\n"
+               "    -Q pri 802.1p priority to set. Should be used with 802.1Q (-V).\n"
+               "           Defaults to 0.\n"
 	       "    -r     Raw output: only the MAC/IP address is displayed for each reply.\n"
 	       "    -R     Raw output: Like -r but shows \"the other one\", can  be  combined\n"
 	       "           with -r.\n"
@@ -645,7 +648,7 @@ standard_usage()
                "              "
                "[ -C <count> ] [ -i <interface> ] [ -m <type> ]\n"
                "              "
-               "[ -V <vlan> ] "
+               "[ -V <vlan> ] [ -Q <priority> ] "
                "<host/ip/MAC | -B>\n");
 }
 
@@ -845,7 +848,7 @@ pingmac_send(uint16_t id, uint16_t seq)
                 eth = libnet_build_802_1q(dstmac,
                                           srcmac,
                                           ETHERTYPE_VLAN,
-                                          0, // priority
+                                          vlan_prio,
                                           0, // cfi
                                           vlan_tag,
                                           ETHERTYPE_IP,
@@ -913,7 +916,7 @@ pingip_send()
                 eth = libnet_build_802_1q(dstmac,
                                           srcmac,
                                           ETHERTYPE_VLAN,
-                                          0, // priority
+                                          vlan_prio,
                                           0, // cfi
                                           vlan_tag,
                                           ETHERTYPE_ARP,
@@ -1376,7 +1379,7 @@ int main(int argc, char **argv)
 	memcpy(dstmac, ethxmas, ETH_ALEN);
 
         while (EOF != (c = getopt(argc, argv,
-                                  "0aAbBC:c:dDeFhi:I:m:pPqrRs:S:t:T:uUvV:w:W:"))) {
+                                  "0aAbBC:c:dDeFhi:I:m:pPqQ:rRs:S:t:T:uUvV:w:W:"))) {
 		switch(c) {
 		case '0':
 			srcip = 0;
@@ -1441,6 +1444,15 @@ int main(int argc, char **argv)
 		case 'q':
 			display = QUIET;
 			break;
+                case 'Q':
+                        vlan_prio = atoi(optarg);
+                        if (vlan_prio < 0 || vlan_prio > 7) {
+                                fprintf(stderr,
+                                        "arping: 802.1p priority must be 0-7. It's %d\n",
+                                        vlan_prio);
+                                exit(1);
+                        }
+                        break;
 		case 'r':
 			display = (display==RRAW)?RAWRAW:RAW;
 			break;
@@ -1544,6 +1556,14 @@ int main(int argc, char **argv)
 			usage(1);
 		}
 	}
+
+        if (vlan_prio >= 0 && vlan_tag == -1) {
+                fprintf(stderr, "arping: -Q requires the use of 802.1Q (-V)\n");
+                exit(1);
+        }
+        if (vlan_prio == -1) {
+                vlan_prio = 0;
+        }
 
         if (verbose > 1) {
 #if HAVE_CLOCK_MONOTONIC


### PR DESCRIPTION
Since the 802.1p priority is a part of the 802.1Q VLAN header, it requires that
the -V option is also specified.
The allowed priority values are 0 (default) - 7.

Signed-off-by: Nikolay Aleksandrov razor@blackwall.org
