### PR TITLE
Avoid relying on implicitly-defined setgroups

### DIFF
--- a/src/arping.c
+++ b/src/arping.c
@@ -105,6 +105,7 @@
 
 #if HAVE_PWD_H
 #include <pwd.h>
+#include <grp.h>
 #endif
 
 #if HAVE_SYS_CAPABILITY_H


### PR DESCRIPTION
Fix potential build errors.

This patch is from the openSUSE project (still used there).