### PR TITLE
Augment return value check of pcap_next_ex

### DIFF
--- a/src/windows.c
+++ b/src/windows.c
@@ -54,7 +54,7 @@ ping_recv_win32(pcap_t *pcap, uint32_t packetwait, pcap_handler func)
        while (!done && !time_to_die) {
 	       struct pcap_pkthdr *pkt_header;
 	       u_char *pkt_data;
-	       if (pcap_next_ex(pcap, &pkt_header, &pkt_data) == 1) {
+	       if (pcap_next_ex(pcap, &pkt_header, &pkt_data) > 0) {
 		       func(pcap, pkt_header, pkt_data);
 	       }
                getclock(&tv);


### PR DESCRIPTION
Although the document of libpcap says pcap_next_ex returns 1 on success. In fact, it returns >0 on success. So it's better to change the return value check to >0. 

See: 
+ libpcap/testprogs/fuzz/fuzz_pcap.c:38
+ libpcap/testprogs/fuzz/fuzz_both.c:39
+ libpcap/testprogs/fuzz/fuzz_rclient.c:22
