### PR TITLE
fixed missing variable for command line parsing

### DIFF
--- a/src/arping.c
+++ b/src/arping.c
@@ -2021,6 +2021,7 @@ arping_main(int argc, char **argv)
         int opt_B = 0;
         int opt_T = 0;
         int opt_U = 0;
+        int c;
         const char* drop_group = NULL;  // -g
         const char *parm; // First argument, meaning the target IP.
 	int maxcount = -1;


### PR DESCRIPTION
Hey, i tried to install your latest release but i got this error:
```
arping.c: In function ‘arping_main’:
arping.c:2052:24: error: ‘c’ undeclared (first use in this function); did you mean ‘cp’?
 2052 |         while (EOF != (c = getopt(argc, argv,
      |                        ^
      |                        cp
```

I've found out that in one of your commits you removed the declaration of the "c" variable, i just re-added it :)