### PR TITLE
Fix compilation error on Loong64.

### DIFF
--- a/src/arping.c
+++ b/src/arping.c
@@ -645,7 +645,11 @@ static void drop_seccomp(int libnet_fd)
         //
 
         // Write to stdout and stderr.
+#if defined(__loongarch64)
+        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(statx), 1, SCMP_A0(SCMP_CMP_EQ, STDOUT_FILENO))) {
+#else
         if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fstat), 1, SCMP_A0(SCMP_CMP_EQ, STDOUT_FILENO))) {
+#endif
                 perror("seccomp_rule_add(fstat stdout)");
                 exit(1);
         }


### PR DESCRIPTION
The system call statx is used instead of stat, lstat and fstat  on LoongArch64.