### PR TITLE
Fix build failures with older kernel headers and non-Linux systems

### DIFF
--- a/src/landlock.c
+++ b/src/landlock.c
@@ -64,7 +64,9 @@ drop_landlock()
                         | LANDLOCK_ACCESS_FS_MAKE_REG
                         | LANDLOCK_ACCESS_FS_MAKE_SOCK
                         | LANDLOCK_ACCESS_FS_MAKE_FIFO
+#ifdef LANDLOCK_ACCESS_FS_REFER
                         | LANDLOCK_ACCESS_FS_REFER
+#endif
                         | LANDLOCK_ACCESS_FS_MAKE_BLOCK
                         | LANDLOCK_ACCESS_FS_MAKE_SYM
 #ifdef LANDLOCK_ACCESS_FS_TRUNCATE

--- a/src/no_new_privs.c
+++ b/src/no_new_privs.c
@@ -24,8 +24,10 @@
 #include <string.h>
 #include <errno.h>
 
+#ifdef __linux__
 #include <linux/prctl.h>  /* Definition of PR_* constants */
 #include <sys/prctl.h>
+#endif
 
 #include "arping.h"
 


### PR DESCRIPTION
Hi. I'm a maintainer for Homebrew. While building arming 2.27 for distribution we encountered some build failures. The changes in this PR help with portability and resolve those failures.

`LANDLOCK_ACCESS_FS_REFER` was added in kernel 5.19 and is not available in older kernel headers. 

`linux/prctl.h` and `sys/prctl.h` do not exist on macOS/BSD.